### PR TITLE
Fixes bug where tabs cannot be displayed, by typesetting the data value sent to the function.

### DIFF
--- a/static/react.js
+++ b/static/react.js
@@ -71,7 +71,7 @@
 		} else if ( parent.className.indexOf( 'emoji-reaction-tab' ) !== -1 ) {
 			event.preventDefault();
 			event.stopPropagation();
-			changeReactionTab( parent.dataset.tab );
+			changeReactionTab( parseInt( parent.dataset.tab ) );
 		} else if ( parent.className.indexOf( 'emoji-reaction' ) !== -1 ) {
 			event.preventDefault();
 			event.stopPropagation();


### PR DESCRIPTION
Noticed a key bug in the demo. Determined it's likely interpreting the data value as a string instead of an int, which is why it'll load tab 0 upon initial page load when explicitly called on Line 158.
